### PR TITLE
assert on Pose2Pose2 factor

### DIFF
--- a/src/factors/Pose2D.jl
+++ b/src/factors/Pose2D.jl
@@ -38,6 +38,7 @@ end
 
 # Assumes X is a tangent vector
 function (cf::CalcFactor{<:Pose2Pose2})(X, p, q)
+    @assert X isa ProductRepr "Pose2Pose2 expects measurement sample X to be a Manifolds tangent vector, not coordinate or point representation.  Got X=$X"
     M = getManifold(Pose2)
     q̂ = Manifolds.compose(M, p, exp(M, identity_element(M, p), X)) #for groups
     return vee(M, q, log(M, q, q̂))

--- a/src/factors/Pose2Point2.jl
+++ b/src/factors/Pose2Point2.jl
@@ -25,11 +25,8 @@ function getSample(cfo::CalcFactor{<:Pose2Point2}, N::Int=1)
   return ([rand(cfo.factor.Zij) for _=1:N], )
 end
 
-function IIF.getMeasurementParametric(s::Pose2Point2{<:MvNormal})
-
-  return IIF.getMeasurementParametric(s.Zij)
-
-end
+# Could also revert to IIF default for Zij
+IIF.getMeasurementParametric(s::Pose2Point2{<:MvNormal}) = getMeasurementParametric(s.Zij)
 
 # define the conditional probability constraint
 function (cfo::CalcFactor{<:Pose2Point2})(meas,
@@ -47,8 +44,8 @@ end
 
 mutable struct PackedPose2Point2 <: IncrementalInference.PackedInferenceType
     Zij::String
-    PackedPose2Point2() = new()
-    PackedPose2Point2(s1::AS) where {AS <: AbstractString} = new(string(s1))
+    # PackedPose2Point2() = new()
+    # PackedPose2Point2(s1::AS) where {AS <: AbstractString} = new(string(s1))
 end
 
 function convert(::Type{PackedPose2Point2}, obj::Pose2Point2{T}) where {T <: IIF.SamplableBelief}


### PR DESCRIPTION
Relates to conversation on #465 , currently taking Pose2Pose2 residual factor to accept only a tangent vector as measurement X.