### PR TITLE
tests must fail on fail with stacktrace

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,39 +14,6 @@ function Statistics.cov(vartype::InferenceVariable, ptsArr::AbstractVector; basi
   cov(getManifold(vartype), ptsArr; basis, kwargs... )
 end
 
-# ## FIXME remove
-# #  quick and dirty skipping of broken testsets
-# mutable struct BrokenTestSet <: Test.AbstractTestSet
-#   description::AbstractString
-#   result::Vector
-#   n_pass::Int
-#   n_broken::Int
-#   n_fail::Int
-#   n_error::Int
-# end
-
-# BrokenTestSet(desc) = BrokenTestSet(desc,[],0,0,0,0)
-
-# Test.record(ts::BrokenTestSet, child::BrokenTestSet) = push!(ts.result, child)
-# Test.record(ts::BrokenTestSet, t::Test.Pass) = (ts.n_pass += 1; t)
-# Test.record(ts::BrokenTestSet, t::Test.Broken) = (ts.n_broken += 1; t)
-# Test.record(ts::BrokenTestSet, t::Test.Fail) = (ts.n_fail += 1; t)
-# Test.record(ts::BrokenTestSet, t::Test.Error) = (ts.n_error += 1; t)
-
-# function Test.finish(ts::BrokenTestSet)
-#   # just record if we're not the top-level parent
-#   if Test.get_testset_depth() > 0
-#       Test.record(Test.get_testset(), ts)
-#   end
-#   printstyled("Broken testset: ", ts.description, "\n"; bold=true)
-#   printstyled("Results:  ")
-#   printstyled("pass:$(ts.n_pass) ";color=:green)
-#   printstyled("broken:$(ts.n_broken) "; color=:yellow)
-#   printstyled("fail:$(ts.n_fail) "; color=:red)
-#   printstyled("error:$(ts.n_error)\n"; color=:red)
-#   ts
-# end
-# ## end #FIXME remove
 
 @error("must restore testG2oParser.jl")
 @error("must restore testParametric.jl")
@@ -89,7 +56,6 @@ testfiles = [
 # "HexagonalLightGraphs.jl"
 # "testCameraFunctions.jl"
 # "testmultiplefeatures.jl"
-# "testPoint2Point2WorldBearing.jl";  # deprecate
 
 
 # test_results = @testset BrokenTestSet "Broken Testset for RoME" begin
@@ -103,16 +69,3 @@ for testf in testfiles
 end
 # end
 
-
-# n_pass = mapreduce(x->x.n_pass, +, test_results.result)
-# n_error = mapreduce(x->x.n_error, +, test_results.result)
-# n_fail = mapreduce(x->x.n_fail, +, test_results.result)
-# n_broken = mapreduce(x->x.n_broken, +, test_results.result)
-
-# printstyled("Broken Testset for RoME summary: \n"; bold=true)
-# printstyled("  Pass:$(n_pass)\n";color=:green)
-# printstyled("  Broken:$(n_broken)\n"; color=:yellow)
-# printstyled("  Fail:$(n_fail)\n"; color=:red)
-# printstyled("  Error:$(n_error)\n"; color=:red)
-
-# 0 < n_error ? error("RoME tests failed") : nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,39 +14,39 @@ function Statistics.cov(vartype::InferenceVariable, ptsArr::AbstractVector; basi
   cov(getManifold(vartype), ptsArr; basis, kwargs... )
 end
 
-## FIXME remove
-#  quick and dirty skipping of broken testsets
-mutable struct BrokenTestSet <: Test.AbstractTestSet
-  description::AbstractString
-  result::Vector
-  n_pass::Int
-  n_broken::Int
-  n_fail::Int
-  n_error::Int
-end
+# ## FIXME remove
+# #  quick and dirty skipping of broken testsets
+# mutable struct BrokenTestSet <: Test.AbstractTestSet
+#   description::AbstractString
+#   result::Vector
+#   n_pass::Int
+#   n_broken::Int
+#   n_fail::Int
+#   n_error::Int
+# end
 
-BrokenTestSet(desc) = BrokenTestSet(desc,[],0,0,0,0)
+# BrokenTestSet(desc) = BrokenTestSet(desc,[],0,0,0,0)
 
-Test.record(ts::BrokenTestSet, child::BrokenTestSet) = push!(ts.result, child)
-Test.record(ts::BrokenTestSet, t::Test.Pass) = (ts.n_pass += 1; t)
-Test.record(ts::BrokenTestSet, t::Test.Broken) = (ts.n_broken += 1; t)
-Test.record(ts::BrokenTestSet, t::Test.Fail) = (ts.n_fail += 1; t)
-Test.record(ts::BrokenTestSet, t::Test.Error) = (ts.n_error += 1; t)
+# Test.record(ts::BrokenTestSet, child::BrokenTestSet) = push!(ts.result, child)
+# Test.record(ts::BrokenTestSet, t::Test.Pass) = (ts.n_pass += 1; t)
+# Test.record(ts::BrokenTestSet, t::Test.Broken) = (ts.n_broken += 1; t)
+# Test.record(ts::BrokenTestSet, t::Test.Fail) = (ts.n_fail += 1; t)
+# Test.record(ts::BrokenTestSet, t::Test.Error) = (ts.n_error += 1; t)
 
-function Test.finish(ts::BrokenTestSet)
-  # just record if we're not the top-level parent
-  if Test.get_testset_depth() > 0
-      Test.record(Test.get_testset(), ts)
-  end
-  printstyled("Broken testset: ", ts.description, "\n"; bold=true)
-  printstyled("Results:  ")
-  printstyled("pass:$(ts.n_pass) ";color=:green)
-  printstyled("broken:$(ts.n_broken) "; color=:yellow)
-  printstyled("fail:$(ts.n_fail) "; color=:red)
-  printstyled("error:$(ts.n_error)\n"; color=:red)
-  ts
-end
-## end #FIXME remove
+# function Test.finish(ts::BrokenTestSet)
+#   # just record if we're not the top-level parent
+#   if Test.get_testset_depth() > 0
+#       Test.record(Test.get_testset(), ts)
+#   end
+#   printstyled("Broken testset: ", ts.description, "\n"; bold=true)
+#   printstyled("Results:  ")
+#   printstyled("pass:$(ts.n_pass) ";color=:green)
+#   printstyled("broken:$(ts.n_broken) "; color=:yellow)
+#   printstyled("fail:$(ts.n_fail) "; color=:red)
+#   printstyled("error:$(ts.n_error)\n"; color=:red)
+#   ts
+# end
+# ## end #FIXME remove
 
 @error("must restore testG2oParser.jl")
 @error("must restore testParametric.jl")
@@ -92,7 +92,7 @@ testfiles = [
 # "testPoint2Point2WorldBearing.jl";  # deprecate
 
 
-test_results = @testset BrokenTestSet "Broken Testset for RoME" begin
+# test_results = @testset BrokenTestSet "Broken Testset for RoME" begin
 for testf in testfiles
   println("[TEST] $testf")
   include(testf)
@@ -101,18 +101,18 @@ for testf in testfiles
   println()
   println()
 end
-end
+# end
 
 
-n_pass = mapreduce(x->x.n_pass, +, test_results.result)
-n_error = mapreduce(x->x.n_error, +, test_results.result)
-n_fail = mapreduce(x->x.n_fail, +, test_results.result)
-n_broken = mapreduce(x->x.n_broken, +, test_results.result)
+# n_pass = mapreduce(x->x.n_pass, +, test_results.result)
+# n_error = mapreduce(x->x.n_error, +, test_results.result)
+# n_fail = mapreduce(x->x.n_fail, +, test_results.result)
+# n_broken = mapreduce(x->x.n_broken, +, test_results.result)
 
-printstyled("Broken Testset for RoME summary: \n"; bold=true)
-printstyled("  Pass:$(n_pass)\n";color=:green)
-printstyled("  Broken:$(n_broken)\n"; color=:yellow)
-printstyled("  Fail:$(n_fail)\n"; color=:red)
-printstyled("  Error:$(n_error)\n"; color=:red)
+# printstyled("Broken Testset for RoME summary: \n"; bold=true)
+# printstyled("  Pass:$(n_pass)\n";color=:green)
+# printstyled("  Broken:$(n_broken)\n"; color=:yellow)
+# printstyled("  Fail:$(n_fail)\n"; color=:red)
+# printstyled("  Error:$(n_error)\n"; color=:red)
 
-0 < n_error ? error("RoME tests failed") : nothing
+# 0 < n_error ? error("RoME tests failed") : nothing


### PR DESCRIPTION
now that Manifolds.jl transition is coming to a end, we must fix IIF and RoME to get the tests restored