### PR TITLE
fix Pose2 preambleCache bug

### DIFF
--- a/src/factors/Pose2D.jl
+++ b/src/factors/Pose2D.jl
@@ -22,26 +22,24 @@ Pose2Pose2(::UniformScaling) = Pose2Pose2()
 
 function preambleCache(dfg::AbstractDFG, vars::AbstractVector{<:DFGVariable}, pp::Pose2Pose2)
   M = getManifold(pp)
-  (;manifold=M, ϵ0=identity_element(M), Xc=zeros(3))
+  (;manifold=M, ϵ0=identity_element(M), Xc=zeros(3), q̂=identity_element(M))
 end
 
 # Assumes X is a tangent vector
 function (cf::CalcFactor{<:Pose2Pose2})(X, p, q)
-    @assert X isa ProductRepr "Pose2Pose2 expects measurement sample X to be a Manifolds tangent vector, not coordinate or point representation.  Got X=$X"
-
-    # @info "HERE" cf.cache
+    @assert X isa ProductRepr || X isa Manifolds.ArrayPartition "Pose2Pose2 expects measurement sample X to be a Manifolds tangent vector, not coordinate or point representation.  Got X=$X"
+    
     M = cf.cache.manifold # getManifold(Pose2)
     ϵ0 = cf.cache.ϵ0
-
-    q̂ = Manifolds.compose(M, p, exp(M, ϵ0, X)) #for groups
-    # q̂ = Manifolds.compose(M, p, exp(M, identity_element(M, p), X)) #for groups
-    #TODO allocalte for vee! see Manifolds #412, fix for AD
+    q̂ = cf.cache.q̂
+    
+    #for groups
+    Manifolds.compose!(M, q̂, p, exp(M, ϵ0, X)) 
     fill!(cf.cache.Xc, 0.0)
-    # Xc = zeros(3)
     vee!(M, cf.cache.Xc, q, log(M, q, q̂))
     return cf.cache.Xc
 end
-  
+
 
 
 # NOTE, serialization support -- will be reduced to macro in future

--- a/src/factors/Pose2D.jl
+++ b/src/factors/Pose2D.jl
@@ -20,7 +20,7 @@ DFG.getManifold(::InstanceType{Pose2Pose2}) = getManifold(Pose2) # Manifolds.Spe
 
 Pose2Pose2(::UniformScaling) = Pose2Pose2()
 
-function preambleCache(pp::Pose2Pose2)
+function preambleCache(dfg::AbstractDFG, vars::AbstractVector{<:DFGVariable}, pp::Pose2Pose2)
   M = getManifold(pp)
   (;manifold=M, ϵ0=identity_element(M), Xc=zeros(3))
 end
@@ -29,7 +29,7 @@ end
 function (cf::CalcFactor{<:Pose2Pose2})(X, p, q)
     @assert X isa ProductRepr "Pose2Pose2 expects measurement sample X to be a Manifolds tangent vector, not coordinate or point representation.  Got X=$X"
 
-    @info "HERE" cf.cache
+    # @info "HERE" cf.cache
     M = cf.cache.manifold # getManifold(Pose2)
     ϵ0 = cf.cache.ϵ0
 


### PR DESCRIPTION
The idea here is to try reduce hot loop memory consumption.  

So just quickly trying on hexagonal example...

Once upon a time, hex would take at best around 30s to solve...  After this PR, and on a computer thermally throttling to around 2.8GHz, hex solves in less than 8 seconds.  Usual caveats of all processes having JIT compiled etc. (that's using 5 processes using Distributed.jl).  Haven't had time to test properly (i've been lazy with fg in global scope).  

TLDR; i expect this PR to reduce the hot loop memory consumption.  Proper testing will tell how much this PR helps, but it seems to be helping somewhere between a little towards a lot.